### PR TITLE
Add dark mode support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,25 +1,34 @@
+import { useEffect, useState } from 'react'
 import Header from "./components/Layout/Header";
 import Navbar from "./components/Layout/Navbar";
 import Sidebar from "./components/Layout/Sidebar";
 import Announcement from "./components/Layout/Announcement";
 
 export default function App() {
+  const [isDark, setIsDark] = useState(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches,
+  )
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDark)
+  }, [isDark])
+
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex flex-col min-h-screen dark:text-gray-100">
       {/* 頁首區塊 */}
-      <header className="bg-white shadow">
-        <Header />
+      <header className="bg-white shadow dark:bg-gray-800">
+        <Header isDark={isDark} toggleDark={() => setIsDark(!isDark)} />
       </header>
 
       {/* 導覽列 + 頁籤 + 跑馬燈 */}
-      <nav className="bg-gray-100 border-b">
+      <nav className="bg-gray-100 border-b dark:bg-gray-900 dark:border-gray-700">
         <Navbar />
       </nav>
 
       {/* 主要內容區 */}
       <main className="flex flex-1">
         {/* 左側側邊欄 */}
-        <aside className="bg-gray-50 border-r">
+        <aside className="bg-gray-50 border-r dark:bg-gray-900 dark:border-gray-700">
           <Sidebar />
         </aside>
 
@@ -34,13 +43,13 @@ export default function App() {
         </section>
 
         {/* 公布欄 */}
-        <aside className="w-80 bg-gray-50 border-l hidden xl:block">
+        <aside className="w-80 bg-gray-50 border-l hidden xl:block dark:bg-gray-900 dark:border-gray-700">
           <Announcement />
         </aside>
       </main>
 
       {/* 頁尾區塊 */}
-      <footer className="bg-white border-t text-center p-2 text-sm text-gray-500">
+      <footer className="bg-white border-t text-center p-2 text-sm text-gray-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400">
         表尾區
       </footer>
     </div>

--- a/src/components/Layout/Announcement.jsx
+++ b/src/components/Layout/Announcement.jsx
@@ -6,17 +6,17 @@ const Announcement = () => {
   return (
     <aside
       className={`relative transition-all duration-300 ease-in-out bg-gray-100 flex flex-col border-l border-gray-300
-        ${collapsed ? 'w-0 overflow-hidden' : 'w-64'}`}
+        ${collapsed ? 'w-0 overflow-hidden' : 'w-64'} dark:bg-gray-900 dark:border-gray-700`}
     >
       <button
         onClick={() => setCollapsed(!collapsed)}
-        className="absolute top-4 -left-6 px-2 py-1 border rounded bg-white text-sm shadow"
+        className="absolute top-4 -left-6 px-2 py-1 border rounded bg-white text-sm shadow dark:bg-gray-800 dark:border-gray-700"
       >
         {collapsed ? '<' : '>'}
       </button>
 
       {!collapsed && (
-        <div className="flex flex-col gap-2 text-sm p-2">
+        <div className="flex flex-col gap-2 text-sm p-2 dark:text-gray-300">
           <h2 className="font-bold">公告欄</h2>
           <div>📢 公告一</div>
           <div>📢 公告二</div>

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -1,8 +1,7 @@
-import { User, Languages, Moon, LogOut, Banknote } from 'lucide-react';
-
-export default function Header() {
+import { User, Languages, Moon, Sun, LogOut, Banknote } from 'lucide-react';
+export default function Header({ isDark, toggleDark }) {
   return (
-    <div className="flex items-center justify-between px-4 h-14 bg-white border-b">
+    <div className="flex items-center justify-between px-4 h-14 bg-white border-b dark:bg-gray-800 dark:border-gray-700">
       {/* 左邊 LOGO */}
       <div className="flex items-center space-x-2">
         <Banknote className="w-6 h-6 text-green-600" />
@@ -18,23 +17,23 @@ export default function Header() {
       {/* 右邊 使用者資訊區 */}
       <div className="flex items-center gap-5">
         {/* 登入人員資訊 */}
-        <div className="flex items-center gap-1 text-sm text-gray-700">
+      <div className="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
           <User className="w-5 h-5" />
           <span>測試員1</span>
         </div>
 
         {/* 語系切換 */}
-        <button className="hover:text-blue-500">
+        <button className="hover:text-blue-500 dark:hover:text-blue-400">
           <Languages className="w-5 h-5" />
         </button>
 
         {/* 深色模式 */}
-        <button className="hover:text-blue-500">
-          <Moon className="w-5 h-5" />
+        <button onClick={toggleDark} className="hover:text-blue-500 dark:hover:text-blue-400">
+          {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
         </button>
 
         {/* 登出 */}
-        <button className="hover:text-blue-500">
+        <button className="hover:text-blue-500 dark:hover:text-blue-400">
           <LogOut className="w-5 h-5" />
         </button>
       </div>

--- a/src/components/Layout/Navbar.jsx
+++ b/src/components/Layout/Navbar.jsx
@@ -10,9 +10,9 @@ export default function Navbar() {
   ];
 
   return (
-    <div className="flex items-center h-12 bg-gray-100 border-b">
+    <div className="flex items-center h-12 bg-gray-100 border-b dark:bg-gray-900 dark:border-gray-700">
       {/* 左側 系統名稱 占位 w-64 (與 Sidebar 對齊) */}
-      <div className="w-50 px-7 font-bold text-lg whitespace-nowrap">
+      <div className="w-50 px-7 font-bold text-lg whitespace-nowrap dark:text-gray-300">
         ISO文管系統
       </div>
 
@@ -23,7 +23,11 @@ export default function Navbar() {
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
             className={`relative px-2 py-1 text-sm transition
-              ${activeTab === tab.id ? "font-semibold text-blue-600" : "text-gray-700 hover:text-blue-500"}
+              ${
+                activeTab === tab.id
+                  ? "font-semibold text-blue-600"
+                  : "text-gray-700 hover:text-blue-500 dark:text-gray-300 dark:hover:text-blue-400"
+              }
             `}
           >
             {tab.label}

--- a/src/components/Layout/Sidebar.jsx
+++ b/src/components/Layout/Sidebar.jsx
@@ -9,13 +9,13 @@ const sidebarItems = [
 export default function Sidebar() {
   return (
     <aside className="group flex flex-col bg-gray-50 transition-all duration-300
-      w-48 max-sm:w-16">
+      w-48 max-sm:w-16 dark:bg-gray-900">
 
       <div className="flex-1 flex flex-col px-4 max-sm:px-0">
         {sidebarItems.map((item, index) => (
           <div key={index}
             className="flex items-center gap-2 px-2 py-2 hover:bg-gray-200 rounded
-            max-sm:justify-center max-sm:px-0"
+            max-sm:justify-center max-sm:px-0 dark:hover:bg-gray-700"
             title={item.label}>
 
             {item.icon}

--- a/src/index.css
+++ b/src/index.css
@@ -29,12 +29,17 @@ button {
   background: none;
 }
 
-/* 暗色模式 (根據 prefers-color-scheme 自動切換) */
+/* 暗色模式 (根據 prefers-color-scheme 或 class 切換) */
 @media (prefers-color-scheme: dark) {
-
   html,
   body {
     background-color: #181818;
     color: #f0f0f0;
   }
+}
+
+html.dark,
+html.dark body {
+  background-color: #181818;
+  color: #f0f0f0;
 }

--- a/uno.config.js
+++ b/uno.config.js
@@ -1,7 +1,12 @@
-import { defineConfig, presetMini } from 'unocss'
+import { defineConfig, presetWind } from 'unocss'
 import presetAttributify from '@unocss/preset-attributify'
 import presetIcons from '@unocss/preset-icons'
 
 export default defineConfig({
-  presets: [presetMini(), presetAttributify(), presetIcons()]
+  dark: 'class',
+  presets: [
+    presetWind({ dark: 'class' }),
+    presetAttributify(),
+    presetIcons(),
+  ],
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import UnoCSS from 'unocss/vite'


### PR DESCRIPTION
## Summary
- enable class-based dark mode with UnoCSS presetWind
- persist dark setting in document element
- add dark styles and a toggle button in the header
- apply dark variants across layout components
- fix lint error in vite config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841a4aafd70832d88874b87fbacc19f